### PR TITLE
add support for v4 display

### DIFF
--- a/conf/config.toml
+++ b/conf/config.toml
@@ -21,4 +21,5 @@ is_rotated = 0
 # Screen selection. Supported screens:
 # 213v2 | Waveshare 2.13 BW V2
 # 213v3 | Waveshare 2.13 BW V3
+# 213v4 | Waveshare 2.13 BW V4
 screen_type = "213v2"

--- a/pihole_dashboard/__init__.py
+++ b/pihole_dashboard/__init__.py
@@ -74,6 +74,11 @@ elif SCREEN_TYPE == "213v3":
   epd = epd2in13_V3.EPD()
   epd.init()
   epd.Clear(0xFF)
+elif SCREEN_TYPE == "213v4":
+  from waveshare_epd import epd2in13_V4
+  epd = epd2in13_V4.EPD()
+  epd.init()
+  epd.Clear(0xFF)
 
 
 def valid_ip(address):

--- a/scripts/pihole-dashboard-clean-screen
+++ b/scripts/pihole-dashboard-clean-screen
@@ -53,4 +53,9 @@ if __name__ == '__main__':
       epd = epd2in13_V3.EPD()
       epd.init()
       epd.Clear(0xFF)
+    elif SCREEN_TYPE == "213v4":
+      from waveshare_epd import epd2in13_V4
+      epd = epd2in13_V4.EPD()
+      epd.init()
+      epd.Clear(0xFF)
 


### PR DESCRIPTION
Add support for the epd2in13_V4 display model, following the existing pattern for V2 and V3 variants.

Verified working on physical hardware.